### PR TITLE
Adds a solr iterator that uses cursors

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
+nose
 pypandoc
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 elasticsearch==1.6.0
-pysolr==3.3.2
+pysolr==3.3.3
 

--- a/solr_to_es/__main__.py
+++ b/solr_to_es/__main__.py
@@ -3,6 +3,7 @@ import argparse
 from elasticsearch import Elasticsearch
 import elasticsearch.helpers
 import pysolr
+from solrSource import SlowSolrDocs
 
 class SolrEsWrapperIter:
     def __init__(self, solr_itr, es_index, es_type):
@@ -20,60 +21,6 @@ class SolrEsWrapperIter:
         new_doc['_type'] = self.type
         new_doc['_source'] = doc
         return new_doc
-
-
-class InvalidPagingConfigError(RuntimeError):
-    def __init__(self, message):
-        super(RuntimeError, self).__init__(message)
-
-
-class SolrRequestIter:
-    def __init__(self, solr_conn, query, sort, **options):
-        self.query = query
-        self.solr_conn = solr_conn
-        self.lastCursorMark = ''
-        self.cursorMark = '*'
-        self.sort = sort
-
-        try:
-            self.rows = options['rows']
-            del options['rows']
-        except KeyError:
-            self.rows = 0
-        self.options = options
-        self.max = None
-        self.docs = None
-
-    def __iter__(self):
-        response = self.solr_conn.search(self.query, rows=0, **self.options)
-        self.max = response.hits
-        return self
-
-    def next(self):
-        try:
-            if self.docs is not None:
-                try:
-                    return self.docs.next()
-                except StopIteration:
-                    self.docs = None
-            if self.docs is None:
-
-                if self.lastCursorMark != self.cursorMark:
-                    response = self.solr_conn.search(self.query, rows=self.rows,
-                                                     cursorMark=self.cursorMark,
-                                                     sort=self.sort,
-                                                     **self.options)
-                    self.docs = iter(response.docs)
-                    self.lastCursorMark = self.cursorMark
-                    self.cursorMark = response.nextCursorMark
-                    return self.docs.next()
-                else:
-                    raise StopIteration()
-        except pysolr.SolrError as e:
-            if "Cursor" in e.message:
-                raise InvalidPagingConfigError(e.message)
-            raise e
-
 
 
 def parse_args():
@@ -110,7 +57,7 @@ def main():
         args = parse_args()
         es_conn = Elasticsearch(hosts=args['elasticsearch_url'], timeout=args['es_timeout'])
         solr_conn = pysolr.Solr(args['solr_url'])
-        solr_itr = SolrRequestIter(solr_conn, args['solr_query'], rows=args['rows_per_page'])
+        solr_itr = SlowSolrDocs(solr_conn, args['solr_query'], rows=args['rows_per_page'])
         es_actions = SolrEsWrapperIter(solr_itr, args['elasticsearch_index'], args['doc_type'])
         elasticsearch.helpers.bulk(es_conn, es_actions)
     except KeyboardInterrupt:

--- a/solr_to_es/solrSource.py
+++ b/solr_to_es/solrSource.py
@@ -1,0 +1,104 @@
+import pysolr
+
+class InvalidPagingConfigError(RuntimeError):
+    def __init__(self, message):
+        super(RuntimeError, self).__init__(message)
+
+
+class _SolrCursorIter:
+    """ Cursor-based iteration, most performant. Requires a sort on id somewhere
+        in required "sort" argument.
+
+        This is recommended approach for iterating docs in a Solr collection
+        """
+    def __init__(self, solr_conn, query, sort, **options):
+        self.query = query
+        self.solr_conn = solr_conn
+        self.lastCursorMark = ''
+        self.cursorMark = '*'
+        self.sort = sort
+
+        try:
+            self.rows = options['rows']
+            del options['rows']
+        except KeyError:
+            self.rows = 0
+        self.options = options
+        self.max = None
+        self.docs = None
+
+    def __iter__(self):
+        response = self.solr_conn.search(self.query, rows=0, **self.options)
+        self.max = response.hits
+        return self
+
+    def next(self):
+        try:
+            if self.docs is not None:
+                try:
+                    return self.docs.next()
+                except StopIteration:
+                    self.docs = None
+            if self.docs is None:
+
+                if self.lastCursorMark != self.cursorMark:
+                    response = self.solr_conn.search(self.query, rows=self.rows,
+                                                     cursorMark=self.cursorMark,
+                                                     sort=self.sort,
+                                                     **self.options)
+                    self.docs = iter(response.docs)
+                    self.lastCursorMark = self.cursorMark
+                    self.cursorMark = response.nextCursorMark
+                    return self.docs.next()
+                else:
+                    raise StopIteration()
+        except pysolr.SolrError as e:
+            if "Cursor" in e.message:
+                raise InvalidPagingConfigError(e.message)
+            raise e
+
+
+class _SolrPagingIter:
+    """ Traditional search paging, most flexible but will
+        gradually get slower on each request due to deep-paging
+
+        See graph here:
+        http://opensourceconnections.com/blog/2014/07/13/reindexing-collections-with-solrs-cursor-support/
+        """
+    def __init__(self, solr_conn, query, **options):
+        self.current = 0
+        self.query = query
+        self.solr_conn = solr_conn
+        try:
+            self.rows = options['rows']
+            del options['rows']
+        except KeyError:
+            self.rows = 0
+        self.options = options
+        self.max = None
+        self.docs = None
+
+    def __iter__(self):
+        response = self.solr_conn.search(self.query, rows=0, **self.options)
+        self.max = response.hits
+        return self
+
+    def next(self):
+        if self.docs is not None:
+            try:
+                return self.docs.next()
+            except StopIteration:
+                self.docs = None
+        if self.docs is None:
+            if self.current * self.rows < self.max:
+                self.current += 1
+                response = self.solr_conn.search(self.query, rows=self.rows,
+                                                 start=(self.current - 1) * self.rows,
+                                                 **self.options)
+                self.docs = iter(response.docs)
+                return self.docs.next()
+            else:
+                raise StopIteration()
+
+SolrDocs = _SolrCursorIter # recommended, see note for SolrCursorIter
+SlowSolrDocs = _SolrPagingIter

--- a/tests/solrTest.py
+++ b/tests/solrTest.py
@@ -1,0 +1,12 @@
+import unittest
+import pysolr
+from os import environ
+
+class SolrIntegrationTest(unittest.TestCase):
+
+    def setUp(self):
+        stateDecDefault = 'http://solr.quepid.com/solr/statedecoded'
+        stateDecSolr = environ['STATE_DECODED_SOLR'] \
+                       if 'STATE_DECODED_SOLR' in environ \
+                       else stateDecDefault
+        self.solr_conn = pysolr.Solr(stateDecSolr)

--- a/tests/test_solrIteration.py
+++ b/tests/test_solrIteration.py
@@ -1,10 +1,10 @@
 from solrTest import SolrIntegrationTest
-from solr_to_es.__main__ import SolrRequestIter, InvalidPagingConfigError
+from solr_to_es.solrSource import SolrDocs, InvalidPagingConfigError
 
 class SolrIterateTest(SolrIntegrationTest):
 
     def test_basic_op(self):
-        solrReq = SolrRequestIter(solr_conn=self.solr_conn, query="*:*", sort='id desc', rows=10)
+        solrReq = SolrDocs(solr_conn=self.solr_conn, query="*:*", sort='id desc', rows=10)
         solrReq = iter(solrReq)
         nextDoc = solrReq.next()
         assert len(nextDoc['catch_line']) > 0
@@ -12,8 +12,7 @@ class SolrIterateTest(SolrIntegrationTest):
         assert len(nextDoc['catch_line']) > 0
 
     def test_bad_sort(self):
-        import pdb; pdb.set_trace()
-        solrReq = SolrRequestIter(solr_conn=self.solr_conn, query="*:*", sort='score desc', rows=10)
+        solrReq = SolrDocs(solr_conn=self.solr_conn, query="*:*", sort='score desc', rows=10)
         try:
             solrReq = iter(solrReq)
             next(solrReq)

--- a/tests/test_solrIteration.py
+++ b/tests/test_solrIteration.py
@@ -1,0 +1,29 @@
+from solrTest import SolrIntegrationTest
+from solr_to_es.__main__ import SolrRequestIter, InvalidPagingConfigError
+
+class SolrIterateTest(SolrIntegrationTest):
+
+    def test_basic_op(self):
+        solrReq = SolrRequestIter(solr_conn=self.solr_conn, query="*:*", sort='id desc', rows=10)
+        solrReq = iter(solrReq)
+        nextDoc = solrReq.next()
+        assert len(nextDoc['catch_line']) > 0
+        nextDoc = solrReq.next()
+        assert len(nextDoc['catch_line']) > 0
+
+    def test_bad_sort(self):
+        import pdb; pdb.set_trace()
+        solrReq = SolrRequestIter(solr_conn=self.solr_conn, query="*:*", sort='score desc', rows=10)
+        try:
+            solrReq = iter(solrReq)
+            next(solrReq)
+            assert False
+        except InvalidPagingConfigError as e:
+            print e.message
+        except Exception as e:
+            print e
+            raise e
+
+
+
+


### PR DESCRIPTION
## Changelog
- Adds deep cursor paging
- moves iterators to their own python  module
- rename them SolrDocs and SlowSolrDocs
## Did not change
- Left the command line app to use the legacy paging for now
- Have not added circleci on travis, but this should be easy to do now
## Testing notes
- I tested the command line app by copying statedecoded to a local vagrant instance of Elasticsearch. The copy worked, though I can verify that due to our nginx proxy limiting the amount of paging it eventually 403'd from Solr:

``` bash
python ./solr_to_es/__main__.py --solr-query "*:*" --rows-per-page 10 --es-timeout 10 "http://solr.quepid.com/solr/statedecoded" "http://192.168.12.5:9200" std law
```
