### PR TITLE
Add support for specifying Solr fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This will migrate a Solr node to an Elasticsearch index.
 ## Usage
 
 ```
-usage: solr-to-es [-h] [--solr-query SOLR_QUERY]
+usage: solr-to-es [-h] [--solr-query SOLR_QUERY] [--solr-fields COMMA_SEP_FIELDS]
                   [--rows-per-page ROWS_PER_PAGE] [--es-timeout ES_TIMEOUT]
                   solr_url elasticsearch_url elasticsearch_index doc_type
 ```
@@ -31,6 +31,8 @@ solr-to-es.py localhost:8983/solr/node localhost:9200 es_index solr_docs
 `doc_type` is the type of document Elasticsearch should assume you are importing.
 
 `--solr-query` defaults to `*:*`
+
+`--solr-fields` defaults to `` (i.e. all fields)
 
 `--rows-per-page` defaults to `500`
 

--- a/solr_to_es/__main__.py
+++ b/solr_to_es/__main__.py
@@ -68,6 +68,10 @@ def parse_args():
                         type=str,
                         default='*:*')
 
+    parser.add_argument('--solr-fields',
+                        type=str,
+                        default='')
+
     parser.add_argument('elasticsearch_url',
                         type=str)
 
@@ -93,7 +97,8 @@ def main():
         args = parse_args()
         es_conn = Elasticsearch(hosts=args['elasticsearch_url'], timeout=args['es_timeout'])
         solr_conn = pysolr.Solr(args['solr_url'])
-        solr_itr = SolrRequestIter(solr_conn, args['solr_query'], rows=args['rows_per_page'])
+        solr_fields = args['solr_fields'].split() if args['solr_fields'] else ''
+        solr_itr = SolrRequestIter(solr_conn, args['solr_query'], rows=args['rows_per_page'], fl=solr_fields)
         es_actions = SolrEsWrapperIter(solr_itr, args['elasticsearch_index'], args['doc_type'])
         elasticsearch.helpers.bulk(es_conn, es_actions)
     except KeyboardInterrupt:


### PR DESCRIPTION
I've added the possibility to specify the fields to import from Solr using a new command-line argument named `--solr-fields=field1,field2`

Thanks @softwaredoug for the guidance ;-)