### PR TITLE
Made integration ready for Elastic Search 6+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-elasticsearch==1.6.0
+elasticsearch==6.3.0
 pysolr==3.3.3
 


### PR DESCRIPTION
Updating the Elastic Search python package allows to use SOLR-TO-ES walso with Elastic Search 6 and up