### PR TITLE
Using absolute module names (PEP 328)

### DIFF
--- a/solr_to_es/__main__.py
+++ b/solr_to_es/__main__.py
@@ -3,7 +3,7 @@ import argparse
 from elasticsearch import Elasticsearch
 import elasticsearch.helpers
 import pysolr
-from solrSource import SlowSolrDocs
+from solr_to_es.solrSource import SlowSolrDocs
 
 
 class SolrEsWrapperIter:

--- a/tests/test_solrIteration.py
+++ b/tests/test_solrIteration.py
@@ -1,4 +1,4 @@
-from solrTest import SolrIntegrationTest
+from tests.solrTest import SolrIntegrationTest
 from solr_to_es.solrSource import SolrDocs, InvalidPagingConfigError
 
 


### PR DESCRIPTION
More information about PEP 328 is linked, including some rationale:
https://www.python.org/dev/peps/pep-0328/

Since we've got a callable main module we may also need to do:
https://www.python.org/dev/peps/pep-0366/