### PR TITLE
Set elasticsearch version to 5.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-elasticsearch>=6.0.0,<7.0.0
+elasticsearch>=5.0.0,<6.0.0
 pysolr>=3.3.3,<4.0
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 
 setup(name='solr-to-es',
-      version='0.2.1',
+      version='0.3.1',
       description='Export Solr Nodes to Elasticsearch Indexes',
       long_description=read('README.md'),
       long_description_content_type='text/markdown',
@@ -21,7 +21,7 @@ setup(name='solr-to-es',
               'solr-to-es=solr_to_es.__main__:main'
           ]
       },
-      install_requires=['elasticsearch>=6.0.0,<7.0.0',
+      install_requires=['elasticsearch>=5.0.0,<6.0.0',
                         'pysolr>=3.3.3,<4.0'],
       license='Apache License, Version 2.0',
       classifiers=[


### PR DESCRIPTION
I'm not sure if we need to update the solr-to-es version number itself, or if we do, whether we need to do that in this commit. Maybe we should just make a release PR that only has those related changes?