### PR TITLE
Make the argument url of solr work when directly pointing to the select end-point

### DIFF
--- a/solr_to_es/__main__.py
+++ b/solr_to_es/__main__.py
@@ -2,8 +2,9 @@ from __future__ import print_function
 import argparse
 from elasticsearch import Elasticsearch
 import elasticsearch.helpers
-from solr_to_es.solrSource import SlowSolrDocs
 import pysolr
+import requests
+
 
 DEFAULT_ES_MAX_RETRIES = 15
 DEFAULT_ES_INITIAL_BACKOFF = 3
@@ -97,8 +98,12 @@ def main():
         else:
             es_conn = Elasticsearch(hosts=args['elasticsearch_url'], timeout=args['es_timeout'])
 
-        # Split the solr_url into the root and the request handler
-        solr_conn = pysolr.Solr(args['solr_url'].rsplit('/', 1)[0], search_handler=args['solr_url'].rsplit('/', 1)[-1])
+        # append /select to the solr URL if needed
+        test_solr_query = dict(q="*", wt="json")
+        response = requests.get(args['solr_url'], params=test_solr_query)
+        if response.status_code != 200 or "responseHeader" not in response.json():
+            args['solr_url'] = "/".join(args['solr_url'], "select")
+
         solr_fields = args['solr_fields'].split() if args['solr_fields'] else ''
         solr_filter = args['solr_filter'] if args['solr_filter'] else ''
         solr_itr = SlowSolrDocs(args['solr_url'], args['solr_query'], rows=args['rows_per_page'], fl=solr_fields,

--- a/solr_to_es/__main__.py
+++ b/solr_to_es/__main__.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import argparse
 from elasticsearch import Elasticsearch
 import elasticsearch.helpers
+from solr_to_es.solrSource import SlowSolrDocs
 import pysolr
 import requests
 

--- a/solr_to_es/solrSource.py
+++ b/solr_to_es/solrSource.py
@@ -87,7 +87,7 @@ class _SolrPagingIter:
         self.docs = None
 
     def __iter__(self):
-        r = requests.get(self.solr_url+'/select?q=' + self.query + '&wt=json&rows=0')
+        r = requests.get(self.solr_url+'?q=' + self.query + '&wt=json&rows=0')
         response = r.json()
         self.max = response['response']['numFound']
         print("Found %s docs" % self.max)
@@ -102,7 +102,7 @@ class _SolrPagingIter:
         if self.docs is None:
             if self.current * self.rows < self.max:
                 self.current += 1
-                url = self.solr_url+ '/select?q=' + self.query + '&wt=json&rows=' + str(self.rows) + "&start=" + str(((self.current - 1) * self.rows))
+                url = self.solr_url+ '?q=' + self.query + '&wt=json&rows=' + str(self.rows) + "&start=" + str(((self.current - 1) * self.rows))
                 if self.fl:
                     url = url + "&fl=" + (','.join(self.fl))                
                 r = requests.get(url)


### PR DESCRIPTION
The pull request tests the URL given as argument.

If a request works on it (params = {q=*&wt=json}) the argument is left as-is.
If not '/select' is added to the URL.